### PR TITLE
feat: add nestjs module

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/katas/application/KatasApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/katas/application/KatasApplicationService.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.katas.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.katas.domain.KatasModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@Service
+public class KatasApplicationService {
+
+  private final KatasModuleFactory factory;
+
+  public KatasApplicationService() {
+    factory = new KatasModuleFactory();
+  }
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    return factory.buildModule(properties);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/katas/domain/KatasModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/katas/domain/KatasModuleFactory.java
@@ -1,0 +1,26 @@
+package tech.jhipster.lite.generator.katas.domain;
+
+import static tech.jhipster.lite.module.domain.JHipsterModule.from;
+import static tech.jhipster.lite.module.domain.JHipsterModule.moduleBuilder;
+import static tech.jhipster.lite.module.domain.JHipsterModule.to;
+
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+public class KatasModuleFactory {
+
+  private static final JHipsterSource SOURCE = from("katas");
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    //@formatter:off
+    return moduleBuilder(properties)
+      .files()
+        .add(SOURCE.template("katas.spec.ts"), to("./src/katas.spec.ts"))
+        .add(SOURCE.template("vitest.config.ts"), to("./vitest.config.ts"))
+        .add(SOURCE.template("README.md"), to("./README.md"))
+      .and()
+      .build();
+    //@formatter:on
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/katas/infrastructure/primary/KatasModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/katas/infrastructure/primary/KatasModuleConfiguration.java
@@ -1,0 +1,30 @@
+package tech.jhipster.lite.generator.katas.infrastructure.primary;
+
+import static tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.KATAS_DOJO;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.KATAS_TS_VITEST;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.PRETTIER;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.TYPESCRIPT;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.katas.application.KatasApplicationService;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
+import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
+
+@Configuration
+class KatasCoreModulesConfiguration {
+
+  public static final String KATAS = "katas-dojo";
+
+  @Bean
+  JHipsterModuleResource katasModule(KatasApplicationService katas) {
+    return JHipsterModuleResource.builder()
+      .slug(KATAS_TS_VITEST)
+      .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().build())
+      .apiDoc("TS + Vitest", "Make a kata using TypeScript and Vitest")
+      .organization(JHipsterModuleOrganization.builder().feature(KATAS_DOJO).addDependency(TYPESCRIPT).addDependency(PRETTIER).build())
+      .tags("katas-dojo", KATAS)
+      .factory(katas::buildModule);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/nestjs/application/NestJsApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/nestjs/application/NestJsApplicationService.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.nestjs.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.nestjs.domain.NestJsModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@Service
+public class NestJsApplicationService {
+
+  private final NestJsModuleFactory factory;
+
+  public NestJsApplicationService() {
+    factory = new NestJsModuleFactory();
+  }
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    return factory.buildModule(properties);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/nestjs/domain/NestJsModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/nestjs/domain/NestJsModuleFactory.java
@@ -1,0 +1,24 @@
+package tech.jhipster.lite.generator.nestjs.domain;
+
+import static tech.jhipster.lite.module.domain.JHipsterModule.from;
+import static tech.jhipster.lite.module.domain.JHipsterModule.moduleBuilder;
+import static tech.jhipster.lite.module.domain.JHipsterModule.toSrcMainNestJs;
+
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+public class NestJsModuleFactory {
+
+  private static final JHipsterSource SOURCE = from("nestjs");
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    //@formatter:off
+    return moduleBuilder(properties)
+      .files()
+        .add(SOURCE.template("dummy.ts"), toSrcMainNestJs().append("dummy.ts"))
+        .and()
+      .build();
+    //@formatter:on
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/nestjs/infrastructure/primary/NestJsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/nestjs/infrastructure/primary/NestJsModuleConfiguration.java
@@ -1,0 +1,30 @@
+package tech.jhipster.lite.generator.nestjs.infrastructure.primary;
+
+import static tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.SERVER_CORE;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.NESTJS_CORE;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.PRETTIER;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.TYPESCRIPT;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.nestjs.application.NestJsApplicationService;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
+import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
+
+@Configuration
+class NestJsCoreModulesConfiguration {
+
+  public static final String NESTJS = "nestjs";
+
+  @Bean
+  JHipsterModuleResource nestJsModule(NestJsApplicationService nestjs) {
+    return JHipsterModuleResource.builder()
+      .slug(NESTJS_CORE)
+      .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().build())
+      .apiDoc("Backend - NestJS", "Add NestJS API")
+      .organization(JHipsterModuleOrganization.builder().feature(SERVER_CORE).addDependency(TYPESCRIPT).addDependency(PRETTIER).build())
+      .tags("server", NESTJS)
+      .factory(nestjs::buildModule);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
@@ -263,6 +263,10 @@ public final class JHipsterModule {
     return new JHipsterDestination(destination);
   }
 
+  public static JHipsterDestination toSrcMainNestJs() {
+    return JHipsterDestination.SRC_MAIN_NESTJS;
+  }
+
   public static JHipsterDestination toSrcMainJava() {
     return JHipsterDestination.SRC_MAIN_JAVA;
   }

--- a/src/main/java/tech/jhipster/lite/module/domain/file/JHipsterDestination.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/file/JHipsterDestination.java
@@ -9,6 +9,7 @@ import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCover
 
 public class JHipsterDestination {
 
+  public static final JHipsterDestination SRC_MAIN_NESTJS = new JHipsterDestination("src");
   public static final JHipsterDestination SRC_MAIN_JAVA = new JHipsterDestination("src/main/java");
   public static final JHipsterDestination SRC_TEST_JAVA = new JHipsterDestination("src/test/java");
   public static final JHipsterDestination SRC_MAIN_DOCKER = new JHipsterDestination("src/main/docker");

--- a/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteFeatureSlug.java
+++ b/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteFeatureSlug.java
@@ -9,6 +9,7 @@ public enum JHLiteFeatureSlug implements JHipsterFeatureSlugFactory {
   JCACHE("jcache"),
   CLIENT_CORE("client-core"),
   SERVER_CORE("server-core"),
+  KATAS_DOJO("katas-dojo"),
   CLIENT_INTERNATIONALIZATION("client-internationalization"),
   CUCUMBER_AUTHENTICATION("cucumber-authentication"),
   DATASOURCE("datasource"),

--- a/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteFeatureSlug.java
+++ b/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteFeatureSlug.java
@@ -8,6 +8,7 @@ public enum JHLiteFeatureSlug implements JHipsterFeatureSlugFactory {
   AUTHENTICATION_SPRINGDOC("authentication-springdoc"),
   JCACHE("jcache"),
   CLIENT_CORE("client-core"),
+  SERVER_CORE("server-core"),
   CLIENT_INTERNATIONALIZATION("client-internationalization"),
   CUCUMBER_AUTHENTICATION("cucumber-authentication"),
   DATASOURCE("datasource"),

--- a/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
+++ b/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
@@ -102,6 +102,7 @@ public enum JHLiteModuleSlug implements JHipsterModuleSlugFactory {
   PROTOBUF("protobuf"),
   PROTOBUF_BACKWARDS_COMPATIBILITY_CHECK("protobuf-backwards-compatibility-check"),
   REACT_CORE("react-core"),
+  NESTJS_CORE("nestjs-core"),
   REACT_I18N("react-i18next"),
   REACT_JWT("react-jwt"),
   REDIS("redis"),

--- a/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
+++ b/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
@@ -103,6 +103,7 @@ public enum JHLiteModuleSlug implements JHipsterModuleSlugFactory {
   PROTOBUF_BACKWARDS_COMPATIBILITY_CHECK("protobuf-backwards-compatibility-check"),
   REACT_CORE("react-core"),
   NESTJS_CORE("nestjs-core"),
+  KATAS_TS_VITEST("katas-ts-vitest"),
   REACT_I18N("react-i18next"),
   REACT_JWT("react-jwt"),
   REDIS("redis"),

--- a/src/main/resources/generator/dependencies/nestjs/package.json
+++ b/src/main/resources/generator/dependencies/nestjs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "jhlite-dependencies",
+  "version": "0.0.0",
+  "description": "JHipster Lite : used for NestJS dependencies",
+  "license": "Apache-2.0",
+  "type": "module",
+  "dependencies": {}
+}

--- a/src/main/resources/generator/katas/README.md.mustache
+++ b/src/main/resources/generator/katas/README.md.mustache
@@ -1,0 +1,28 @@
+# Template TypeScript Kata with Vitest
+
+This is a basic template to make a kata using [TypeScript](https://www.typescriptlang.org/) and [Vitest](https://vitest.dev/).
+
+## Prerequisites
+
+- [Node](https://nodejs.org/) LTS
+
+## Installation
+
+```shell
+npm install
+```
+
+## Tests
+
+Create a test file in the `src` directory (example: `FizzBuzz.spec.ts`) add a test and run:
+
+To watch tests:
+
+```shell
+npm test
+```
+
+## Tools/Plugins
+
+- [Mob.sh](https://mob.sh/) - For remote pair/mob programming
+- [Git Gamble](https://git-gamble.is-cool.dev/) - To develop baby step by baby step

--- a/src/main/resources/generator/katas/katas.spec.ts.mustache
+++ b/src/main/resources/generator/katas/katas.spec.ts.mustache
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('Kata Dojo', () => {
+  it('should return the correct answer', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/main/resources/generator/katas/vitest.config.ts.mustache
+++ b/src/main/resources/generator/katas/vitest.config.ts.mustache
@@ -1,0 +1,43 @@
+/// <reference types="vitest" />
+
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    reporters: ['verbose', 'vitest-sonar-reporter'],
+    outputFile: {
+      'vitest-sonar-reporter': 'target/test-results/TESTS-results-sonar.xml',
+    },
+    globals: true,
+    logHeapUsage: true,
+    poolOptions: {
+      threads: {
+        minThreads: 1,
+        maxThreads: 2,
+      },
+    },
+    environment: 'node',
+    cache: false,
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    coverage: {
+      thresholds: {
+        perFile: true,
+        autoUpdate: true,
+        100: true,
+      },
+      include: ['src/**/*.ts?(x)'],
+      exclude: [...(configDefaults.coverage.exclude as string[])],
+      provider: 'istanbul',
+      reportsDirectory: 'target/test-results/',
+      reporter: ['html', 'json-summary', 'text', 'text-summary', 'lcov', 'clover'],
+      watermarks: {
+        statements: [100, 100],
+        branches: [100, 100],
+        functions: [100, 100],
+        lines: [100, 100],
+      },
+    },
+  },
+});

--- a/src/main/resources/generator/nestjs/dummy.ts.mustache
+++ b/src/main/resources/generator/nestjs/dummy.ts.mustache
@@ -1,0 +1,3 @@
+export class Dummy {
+
+}

--- a/src/test/features/nestjs.feature
+++ b/src/test/features/nestjs.feature
@@ -1,0 +1,7 @@
+Feature: NestJs Module
+
+  Scenario: Should apply my module
+    When I apply "nestjs" module to default project
+      | packageName | tech.jhipster.chips |
+    Then I should have files in "src/main/java/tech/jhipster/chips/nestjs"
+      | dummy.java |

--- a/src/test/java/tech/jhipster/lite/generator/nestjs/domain/NestJsModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/nestjs/domain/NestJsModuleFactoryTest.java
@@ -1,0 +1,27 @@
+package tech.jhipster.lite.generator.nestjs.domain;
+
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModule;
+
+import org.junit.jupiter.api.Test;
+import tech.jhipster.lite.TestFileUtils;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@UnitTest
+class NestJsFactoryTest {
+
+  private static final NestJsModuleFactory factory = new NestJsModuleFactory();
+
+  @Test
+  void shouldBuildModule() {
+    JHipsterModuleProperties properties = JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
+      .basePackage("tech.jhipster.jhlitest")
+      .build();
+
+    JHipsterModule module = factory.buildModule(properties);
+
+    assertThatModule(module).hasPrefixedFiles("src/main/java/tech/jhipster/jhlitest/nestjs", "dummy.ts");
+  }
+}


### PR DESCRIPTION
ℹ️ La PR part du repo de base de JHipster Lite : https://github.com/jhipster/jhipster-lite

Ici, on a un module NestJs qui pour l'instant ne crée qu'un simple module avec un seul fichier `dummy.ts`. 

Il suffit de créer les bons templates pour avoir un vrai projet Nest avec tous les bons fichiers dedans.

Pour tester, exécuter à la racine du projet : `./mvnw`

**La documentation à suivre est vraiment** [celle-ci](https://github.com/bsureau/test-JHipsterLite/blob/main/documentation/module-creation.md), step by step. Mais en gros : 

1. il faut définir la façon de générer le module dans https://github.com/bsureau/test-JHipsterLite/tree/main/src/main/java/tech/jhipster/lite/generator
2. Puis définir les templates du module (fichiers de base, dépendances...) dans https://github.com/bsureau/test-JHipsterLite/tree/main/src/main/resources/generator

**La prochaine étape** serait de remplacer le fichier `dummy.ts` par une vraie arborescence de projet NestJs.  Puis de virer tous les modules inutiles ? 

**Hypothèses qui restent à confirmer :** 
- à priori on doit pouvoir donner l'arborescence de fichier qu'on veut, selon nos propres standards (archi hexa...)
- la logique me semble en l'état déclinable pour n'importe quel langage/techno


PS : j'ai cassé la pipeline CI, mais je n'ai pas le temps de regarder maintenant...

Enjoy 🍻
